### PR TITLE
Fix x64 compile warnings, except in ext.

### DIFF
--- a/lib/include/colorist/context.h
+++ b/lib/include/colorist/context.h
@@ -101,13 +101,13 @@ typedef enum clFilter
 clFilter clFilterFromString(struct clContext * C, const char * str);
 const char * clFilterToString(struct clContext * C, clFilter filter);
 
-typedef void *(* clContextAllocFunc)(struct clContext * C, int bytes); // C will be NULL when allocating the clContext itself
+typedef void *(* clContextAllocFunc)(struct clContext * C, size_t bytes); // C will be NULL when allocating the clContext itself
 typedef void (* clContextFreeFunc)(struct clContext * C, void * ptr);
 typedef void (* clContextLogFunc)(struct clContext * C, const char * section, int indent, const char * format, va_list args);
 typedef void (* clContextLogErrorFunc)(struct clContext * C, const char * format, va_list args);
 
 // Internal defaults for clContextSystem, use clContextLog*() / clAllocate / clFree below
-void * clContextDefaultAlloc(struct clContext * C, int bytes);
+void * clContextDefaultAlloc(struct clContext * C, size_t bytes);
 void clContextDefaultFree(struct clContext * C, void * ptr);
 void clContextDefaultLog(struct clContext * C, const char * section, int indent, const char * format, va_list args);
 void clContextDefaultLogError(struct clContext * C, const char * format, va_list args);

--- a/lib/include/colorist/profile.h
+++ b/lib/include/colorist/profile.h
@@ -57,7 +57,7 @@ typedef enum clProfileStock
 clProfile * clProfileCreateStock(struct clContext * C, clProfileStock stock);
 clProfile * clProfileClone(struct clContext * C, clProfile * profile);
 clProfile * clProfileCreate(struct clContext * C, clProfilePrimaries * primaries, clProfileCurve * curve, int maxLuminance, const char * description);
-clProfile * clProfileParse(struct clContext * C, const uint8_t * icc, int iccLen, const char * description);
+clProfile * clProfileParse(struct clContext * C, const uint8_t * icc, size_t iccLen, const char * description);
 clProfile * clProfileRead(struct clContext * C, const char * filename);
 clBool clProfileReload(struct clContext * C, clProfile * profile);
 clBool clProfileWrite(struct clContext * C, clProfile * profile, const char * filename);
@@ -72,7 +72,7 @@ clBool clProfileRemoveTag(struct clContext * C, clProfile * profile, char * tag,
 clBool clProfileMatches(struct clContext * C, clProfile * profile1, clProfile * profile2);
 clBool clProfileUsesCCMM(struct clContext * C, clProfile * profile);
 const char * clProfileCMMName(struct clContext * C, clProfile * profile); // Convenience function
-int clProfileSize(struct clContext * C, clProfile * profile);
+size_t clProfileSize(struct clContext * C, clProfile * profile);
 void clProfileDebugDump(struct clContext * C, clProfile * profile, clBool dumpTags, int extraIndent);
 void clProfileDebugDumpJSON(struct clContext * C, struct cJSON * jsonOutput, clProfile * profile, clBool dumpTags);
 void clProfileDestroy(struct clContext * C, clProfile * profile);

--- a/lib/include/colorist/raw.h
+++ b/lib/include/colorist/raw.h
@@ -13,7 +13,7 @@
 typedef struct clRaw
 {
     uint8_t * ptr;
-    uint32_t size;
+    size_t size;
 } clRaw;
 
 typedef struct clStructArraySchema
@@ -24,11 +24,11 @@ typedef struct clStructArraySchema
 
 struct clContext;
 
-void clRawRealloc(struct clContext * C, clRaw * raw, uint32_t newSize);
+void clRawRealloc(struct clContext * C, clRaw * raw, size_t newSize);
 void clRawClone(struct clContext * C, clRaw * dst, const clRaw * src);
 clBool clRawDeflate(struct clContext * C, clRaw * dst, const clRaw * src);
 char * clRawToBase64(struct clContext * C, clRaw * src);
-void clRawSet(struct clContext * C, clRaw * raw, const uint8_t * data, uint32_t len);
+void clRawSet(struct clContext * C, clRaw * raw, const uint8_t * data, size_t len);
 void clRawFree(struct clContext * C, clRaw * raw);
 clBool clRawReadFile(struct clContext * C, clRaw * raw, const char * filename);
 clBool clRawWriteFile(struct clContext * C, clRaw * raw, const char * filename);

--- a/lib/src/context.c
+++ b/lib/src/context.c
@@ -391,7 +391,7 @@ clBool clContextGetRawStockPrimaries(struct clContext * C, const char * name, fl
 
 char * clContextStrdup(clContext * C, const char * str)
 {
-    int len = strlen(str);
+    size_t len = strlen(str);
     char * dup = clAllocate(len + 1);
     memcpy(dup, str, len);
     dup[len] = 0;

--- a/lib/src/context_log.c
+++ b/lib/src/context_log.c
@@ -67,7 +67,7 @@ void clContextDefaultLog(clContext * C, const char * section, int indent, const 
 {
     if (section) {
         char spaces[10] = "         ";
-        int spacesNeeded = 9 - strlen(section);
+        int spacesNeeded = 9 - (int)strlen(section);
         spacesNeeded = CL_CLAMP(spacesNeeded, 0, 9);
         spaces[spacesNeeded] = 0;
         fprintf(stdout, "[%s%s] ", spaces, section);

--- a/lib/src/context_memory.c
+++ b/lib/src/context_memory.c
@@ -17,7 +17,7 @@
 
 #include <stdlib.h>
 
-void * clContextDefaultAlloc(struct clContext * C, int bytes)
+void * clContextDefaultAlloc(struct clContext * C, size_t bytes)
 {
     return calloc(1, bytes);
 

--- a/lib/src/context_report.c
+++ b/lib/src/context_report.c
@@ -457,14 +457,14 @@ int clContextReport(clContext * C)
         static const char coloristDataMarker[] = "__COLORIST_DATA__";
         const char * coloristDataInjectLoc = strstr((const char *)reportTemplateBinaryData, coloristDataMarker);
         const char * afterPtr;
-        int beforeLen, afterLen;
+        size_t beforeLen, afterLen;
         char * payloadString;
         if (!coloristDataInjectLoc) {
             clContextLogError(C, "Template does not contain the string \"%s\", bailing out", coloristDataMarker);
             FAIL();
         }
 
-        beforeLen = (int)(coloristDataInjectLoc - (const char *)reportTemplateBinaryData);
+        beforeLen = (coloristDataInjectLoc - (const char *)reportTemplateBinaryData);
         afterPtr = coloristDataInjectLoc + strlen(coloristDataMarker);
         afterLen = strlen(afterPtr);
 

--- a/lib/src/context_rw.c
+++ b/lib/src/context_rw.c
@@ -94,7 +94,7 @@ char * clContextWriteURI(struct clContext * C, clImage * image, const char * for
 {
     clRaw dst;
     char * b64;
-    int b64Len;
+    size_t b64Len;
     char * output = NULL;
     clWriteParams writeParams;
 
@@ -111,7 +111,7 @@ char * clContextWriteURI(struct clContext * C, clImage * image, const char * for
     if (format->writeFunc) {
         if (format->writeFunc(C, image, formatName, &dst, &writeParams)) {
             char prefix[512];
-            int prefixLen = sprintf(prefix, "data:%s;base64,", format->mimeType);
+            size_t prefixLen = sprintf(prefix, "data:%s;base64,", format->mimeType);
 
             b64 = clRawToBase64(C, &dst);
             if (!b64) {

--- a/lib/src/format_bmp.c
+++ b/lib/src/format_bmp.c
@@ -269,7 +269,7 @@ clBool clFormatWriteBMP(struct clContext * C, struct clImage * image, const char
     info.bV5CSType = PROFILE_EMBEDDED;
     info.bV5Intent = LCS_GM_ABS_COLORIMETRIC;
     info.bV5ProfileData = sizeof(info);
-    info.bV5ProfileSize = rawProfile.size;
+    info.bV5ProfileSize = (uint32_t)rawProfile.size;
 
     packedPixelBytes = sizeof(uint32_t) * info.bV5Width * info.bV5Height;
     packedPixels = clAllocate(packedPixelBytes);
@@ -306,7 +306,7 @@ clBool clFormatWriteBMP(struct clContext * C, struct clImage * image, const char
     }
 
     memset(&fileHeader, 0, sizeof(fileHeader));
-    fileHeader.bfOffBits = sizeof(magic) + sizeof(fileHeader) + sizeof(info) + rawProfile.size;
+    fileHeader.bfOffBits = (uint32_t)(sizeof(magic) + sizeof(fileHeader) + sizeof(info) + rawProfile.size);
     fileHeader.bfSize = fileHeader.bfOffBits + packedPixelBytes;
 
     clRawRealloc(C, output, fileHeader.bfSize);

--- a/lib/src/format_jp2.c
+++ b/lib/src/format_jp2.c
@@ -37,7 +37,7 @@ struct opjCallbackInfo
 {
     struct clContext * C;
     clRaw * raw;
-    uint32_t offset;
+    OPJ_OFF_T offset;
 };
 
 static OPJ_SIZE_T readCallback(void * p_buffer, OPJ_SIZE_T p_nb_bytes, void * p_user_data)
@@ -55,7 +55,7 @@ static OPJ_SIZE_T writeCallback(void * p_buffer, OPJ_SIZE_T p_nb_bytes, void * p
 {
     struct opjCallbackInfo * ci = (struct opjCallbackInfo *)p_user_data;
     if ((ci->offset + p_nb_bytes) > ci->raw->size) {
-        uint32_t newSize = ci->offset + p_nb_bytes;
+        size_t newSize = ci->offset + p_nb_bytes;
         clRawRealloc(ci->C, ci->raw, newSize);
     }
     memcpy(ci->raw->ptr + ci->offset, p_buffer, p_nb_bytes);
@@ -344,7 +344,7 @@ clBool clFormatWriteJP2(struct clContext * C, struct clImage * image, const char
     }
     opjImage->icc_profile_buf = opj_malloc(rawProfile.size);
     memcpy(opjImage->icc_profile_buf, rawProfile.ptr, rawProfile.size);
-    opjImage->icc_profile_len = rawProfile.size;
+    opjImage->icc_profile_len = (OPJ_UINT32)rawProfile.size;
 
     opj_set_info_handler(opjCodec, info_callback, C);
     opj_set_warning_handler(opjCodec, warning_callback, C);

--- a/lib/src/format_jpg.c
+++ b/lib/src/format_jpg.c
@@ -56,7 +56,7 @@ struct clImage * clFormatReadJPG(struct clContext * C, const char * formatName, 
 
     jpeg_create_decompress(&cinfo);
     setup_read_icc_profile(&cinfo);
-    jpeg_mem_src(&cinfo, input->ptr, input->size);
+    jpeg_mem_src(&cinfo, input->ptr, (unsigned long)input->size);
     jpeg_read_header(&cinfo, TRUE);
     jpeg_start_decompress(&cinfo);
 
@@ -141,7 +141,7 @@ clBool clFormatWriteJPG(struct clContext * C, struct clImage * image, const char
     if (!clProfilePack(C, image->profile, &rawProfile)) {
         return clFalse;
     }
-    write_icc_profile(&cinfo, rawProfile.ptr, rawProfile.size);
+    write_icc_profile(&cinfo, rawProfile.ptr, (unsigned int)rawProfile.size);
 
     row_stride = image->width * 3;
     while (cinfo.next_scanline < cinfo.image_height) {

--- a/lib/src/format_png.c
+++ b/lib/src/format_png.c
@@ -18,7 +18,7 @@ struct readInfo
 {
     struct clContext * C;
     clRaw * src;
-    uint32_t offset;
+    png_size_t offset;
 };
 
 static void readCallback(png_structp png, png_bytep data, png_size_t length)
@@ -141,14 +141,14 @@ struct writeInfo
 {
     struct clContext * C;
     clRaw * dst;
-    uint32_t offset;
+    png_size_t offset;
 };
 
 static void writeCallback(png_structp png, png_bytep data, png_size_t length)
 {
     struct writeInfo * wi = (struct writeInfo *)png_get_io_ptr(png);
     if ((wi->offset + length) > wi->dst->size) {
-        uint32_t newSize = wi->dst->size;
+        size_t newSize = wi->dst->size;
         if (!newSize)
             newSize = 8;
         do {
@@ -193,7 +193,7 @@ clBool clFormatWritePNG(struct clContext * C, struct clImage * image, const char
         PNG_COMPRESSION_TYPE_DEFAULT,
         PNG_FILTER_TYPE_DEFAULT
         );
-    png_set_iCCP(png, info, image->profile->description, 0, rawProfile.ptr, rawProfile.size);
+    png_set_iCCP(png, info, image->profile->description, 0, rawProfile.ptr, (png_uint_32)rawProfile.size);
     png_write_info(png, info);
 
     rowPointers = (png_bytep *)clAllocate(sizeof(png_bytep) * image->height);

--- a/lib/src/format_tiff.c
+++ b/lib/src/format_tiff.c
@@ -18,7 +18,7 @@ typedef struct tiffCallbackInfo
 {
     struct clContext * C;
     clRaw * raw;
-    uint32_t offset;
+    toff_t offset;
 } tiffCallbackInfo;
 
 static tmsize_t readCallback(tiffCallbackInfo *ci, void* ptr, tmsize_t size)
@@ -34,7 +34,7 @@ static tmsize_t readCallback(tiffCallbackInfo *ci, void* ptr, tmsize_t size)
 static tmsize_t writeCallback(tiffCallbackInfo *ci, void* ptr, tmsize_t size)
 {
     if ((ci->offset + size) > ci->raw->size) {
-        uint32_t newSize = ci->offset + size;
+        tmsize_t newSize = ci->offset + size;
         clRawRealloc(ci->C, ci->raw, newSize);
     }
     memcpy(ci->raw->ptr + ci->offset, ptr, size);

--- a/lib/src/image_string.c
+++ b/lib/src/image_string.c
@@ -98,7 +98,7 @@ static unsigned int hexChannel(const char * hex)
 static const char * parseHashColor(struct clContext * C, const char * s, clColor * parsedColor)
 {
     const char * end;
-    int len;
+    size_t len;
 
     if (*s != '#') {
         clContextLogError(C, "hash color does not begin with #");
@@ -143,7 +143,7 @@ static const char * parseParenColor(struct clContext * C, const char * s, int de
 {
     char * buffer;
     const char * end;
-    int len;
+    size_t len;
     char * token;
     int index = 0;
     int ints[4];
@@ -335,7 +335,7 @@ static const char * parseRange(struct clContext * C, const char * s, clToken * t
         return s + 2;
     } else {
         char buffer[32];
-        int len;
+        size_t len;
         const char * end = ++s;
         while (isdigit(*end)) {
             ++end;
@@ -385,7 +385,7 @@ static clBool finishRange(struct clContext * C, clToken * token)
 static const char * parseDimensions(struct clContext * C, const char * s, clToken * token)
 {
     char buffer[32];
-    int len;
+    size_t len;
     const char * end;
 
     // Width
@@ -435,7 +435,7 @@ static const char * parseDimensions(struct clContext * C, const char * s, clToke
 static const char * parseRepeat(struct clContext * C, const char * s, clToken * token)
 {
     char buffer[32];
-    int len;
+    size_t len;
     const char * end;
     if (*s != 'x') {
         clContextLogError(C, "repeat not begin with x");

--- a/lib/src/profile.c
+++ b/lib/src/profile.c
@@ -61,10 +61,10 @@ clProfile * clProfileClone(struct clContext * C, clProfile * profile)
     return clone;
 }
 
-clProfile * clProfileParse(struct clContext * C, const uint8_t * icc, int iccLen, const char * description)
+clProfile * clProfileParse(struct clContext * C, const uint8_t * icc, size_t iccLen, const char * description)
 {
     clProfile * profile = clAllocateStruct(clProfile);
-    profile->handle = cmsOpenProfileFromMemTHR(C->lcms, icc, iccLen);
+    profile->handle = cmsOpenProfileFromMemTHR(C->lcms, icc, (cmsUInt32Number)iccLen);
     if (!profile->handle) {
         clFree(profile);
         return NULL;
@@ -88,7 +88,7 @@ clProfile * clProfileParse(struct clContext * C, const uint8_t * icc, int iccLen
     {
         MD5_CTX ctx;
         MD5_Init(&ctx);
-        MD5_Update(&ctx, icc, iccLen);
+        MD5_Update(&ctx, icc, (unsigned long)iccLen);
         MD5_Final(profile->signature, &ctx);
     }
 
@@ -174,9 +174,9 @@ clBool clProfilePack(struct clContext * C, clProfile * profile, clRaw * out)
     return clTrue;
 }
 
-int clProfileSize(struct clContext * C, clProfile * profile)
+size_t clProfileSize(struct clContext * C, clProfile * profile)
 {
-    int ret;
+    size_t ret;
     if (profile->raw.size > 0) {
         ret = profile->raw.size;
     } else {
@@ -218,7 +218,7 @@ clBool clProfileWrite(struct clContext * C, clProfile * profile, const char * fi
 {
     clRaw rawProfile;
     FILE * f;
-    int itemsWritten;
+    size_t itemsWritten;
 
     f = fopen(filename, "wb");
     if (!f) {

--- a/lib/src/profile_debugdump.c
+++ b/lib/src/profile_debugdump.c
@@ -106,7 +106,7 @@ void clProfileDebugDumpJSON(struct clContext * C, struct cJSON * jsonOutput, clP
         cJSON * jsonCurve;
 
         cJSON_AddStringToObject(jsonOutput, "description", profile->description);
-        cJSON_AddNumberToObject(jsonOutput, "size", clProfileSize(C, profile));
+        cJSON_AddNumberToObject(jsonOutput, "size", (double)clProfileSize(C, profile));
 
         tempStr = clProfileGetMLU(C, profile, "cprt", "en", "US");
         if (tempStr) {

--- a/lib/src/raw.c
+++ b/lib/src/raw.c
@@ -13,15 +13,15 @@
 #include "zlib.h"
 #include <string.h>
 
-void clRawRealloc(struct clContext * C, clRaw * raw, uint32_t newSize)
+void clRawRealloc(struct clContext * C, clRaw * raw, size_t newSize)
 {
     if (raw->size != newSize) {
         uint8_t * old = raw->ptr;
-        uint32_t oldSize = raw->size;
+        size_t oldSize = raw->size;
         raw->ptr = clAllocate(newSize);
         raw->size = newSize;
         if (oldSize) {
-            uint32_t bytesToCopy = (oldSize < raw->size) ? oldSize : raw->size;
+            size_t bytesToCopy = (oldSize < raw->size) ? oldSize : raw->size;
             memcpy(raw->ptr, old, bytesToCopy);
             clFree(old);
         }
@@ -38,12 +38,14 @@ clBool clRawDeflate(struct clContext * C, clRaw * dst, const clRaw * src)
     clBool ret = clTrue;
     z_stream z;
     int err;
-    int maxDeflatedSize = src->size + 6 + (((src->size + 16383) / 16384) * 5);
+    size_t maxDeflatedSize = src->size + 6 + (((src->size + 16383) / 16384) * 5);
     clRawRealloc(C, dst, maxDeflatedSize);
 
     memset(&z, 0, sizeof(z));
-    z.total_in = z.avail_in = src->size;
-    z.total_out = z.avail_out = dst->size;
+    z.total_in = (uLong)src->size;
+    z.avail_in = (uInt)src->size;
+    z.total_out = (uLong)dst->size;
+    z.avail_out = (uInt)dst->size;
     z.next_in = src->ptr;
     z.next_out = dst->ptr;
 
@@ -133,7 +135,7 @@ char * clRawToBase64(struct clContext * C, clRaw * src)
     return (char *)out;
 }
 
-void clRawSet(struct clContext * C, clRaw * raw, const uint8_t * data, uint32_t len)
+void clRawSet(struct clContext * C, clRaw * raw, const uint8_t * data, size_t len)
 {
     if (len) {
         clRawRealloc(C, raw, len);


### PR DESCRIPTION
Fixes all of the compile warnings for x64 builds (which run slightly faster than x86), except for code in the "ext" directory, specifically jpeg and tiff libraries.