### PR TITLE
Disable clang warning for recursive macro expansion, happens in some …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wno-covered-switch-default
     -Wno-double-promotion
     -Wno-deprecated-declarations
+    -Wno-disabled-macro-expansion
     -Wno-format-nonliteral
     -Wno-language-extension-token
     -Wno-missing-noreturn


### PR DESCRIPTION
…system headers