### PR TITLE
Update AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,48 +1,33 @@
-version: '{build}'
-skip_non_tags: true
 image: Visual Studio 2017
 configuration: Release
-init:
-- cmd: >-
-    set arch=Win64
 
-    if "%arch%"=="Win64" ( set arch= Win64)
-
-    echo %arch%
-
-    echo %APPVEYOR_BUILD_WORKER_IMAGE%
-
-    if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set generator="Visual Studio 15 2017%arch%" )
-
-    if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set generator="Visual Studio 14 2015%arch%" )
-
-    if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" ( set generator="Visual Studio 12 2013%arch%" )
-
-    echo %generator%
 before_build:
 - cmd: >-
     appveyor DownloadFile "https://github.com/joedrago/nasm_mirror/raw/master/nasm-2.14.02-win64.zip" -FileName "nasm.zip"
-
     7z x "nasm.zip" > nul
-
     move nasm-* NASM
-
     set PATH=%PATH%;%CD%\NASM;
-
     nasm -v
 
-
     mkdir build
-
     cd build
-
     cmake --version
+    cmake .. -A x64
 
-    cmake .. -G %generator%
 build:
   project: C:/projects/colorist/build/colorist.sln
   parallel: true
   verbosity: minimal
+
 artifacts:
 - path: build\bin\colorist\Release\colorist.exe
   name: colorist.exe
+  
+deploy:
+  - provider: GitHub
+    artifact: build\bin\colorist\Release\colorist.exe
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,16 @@ image: Visual Studio 2017
 configuration: Release
 
 before_build:
-- cmd: >-
-    appveyor DownloadFile "https://github.com/joedrago/nasm_mirror/raw/master/nasm-2.14.02-win64.zip" -FileName "nasm.zip"
-    7z x "nasm.zip" > nul
-    move nasm-* NASM
-    set PATH=%PATH%;%CD%\NASM;
-    nasm -v
+  - appveyor DownloadFile "https://github.com/joedrago/nasm_mirror/raw/master/nasm-2.14.02-win64.zip" -FileName "nasm.zip"
+  - 7z x "nasm.zip" > nul
+  - move nasm-* NASM
+  - set PATH=%PATH%;%CD%\NASM;
+  - nasm -v
 
-    mkdir build
-    cd build
-    cmake --version
-    cmake .. -A x64
+  - mkdir build
+  - cd build
+  - cmake --version
+  - cmake .. -A x64
 
 build:
   project: C:/projects/colorist/build/colorist.sln


### PR DESCRIPTION
- Always run AppVeyor
- Simplify CMake setup & cleanup
- Deploy artifacts to GitHub on Release

I set it up this way so you can always get a Windows build artifact from AppVeyor if you need it for testing, but only release builds are uploaded to GitHub. We can link regular users to the [latest release](https://github.com/joedrago/colorist/releases) for a Windows build.