### PR TITLE
add new highlight tool

### DIFF
--- a/bin/colorist/main.c
+++ b/bin/colorist/main.c
@@ -95,6 +95,9 @@ int main(int argc, char * argv[])
         case CL_ACTION_GENERATE:
             ret = clContextGenerate(C, NULL);
             break;
+        case CL_ACTION_HIGHLIGHT:
+            ret = clContextHighlight(C);
+            break;
         case CL_ACTION_IDENTIFY:
             ret = clContextIdentify(C, jsonOutput);
             break;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ set(COLORIST_LIB_SRCS
     src/context_convert.c
     src/context_formats.c
     src/context_generate.c
+    src/context_highlight.c
     src/context_identify.c
     src/context_log.c
     src/context_memory.c

--- a/lib/include/colorist/context.h
+++ b/lib/include/colorist/context.h
@@ -29,6 +29,7 @@ typedef enum clAction
     CL_ACTION_CALC,
     CL_ACTION_CONVERT,
     CL_ACTION_GENERATE,
+    CL_ACTION_HIGHLIGHT,
     CL_ACTION_IDENTIFY,
     CL_ACTION_MODIFY,
 
@@ -303,6 +304,7 @@ const char * clContextFindStockPrimariesPrettyName(struct clContext * C, struct 
 
 int clContextConvert(clContext * C);
 int clContextGenerate(clContext * C, struct cJSON * output); // output here only used in ACTION_CALC
+int clContextHighlight(clContext * C);
 int clContextIdentify(clContext * C, struct cJSON * output);
 int clContextModify(clContext * C);
 

--- a/lib/src/context.c
+++ b/lib/src/context.c
@@ -48,6 +48,8 @@ clAction clActionFromString(struct clContext * C, const char * str)
 {
     COLORIST_UNUSED(C);
 
+    if (!strcmp(str, "highlight"))
+        return CL_ACTION_HIGHLIGHT;
     if (!strcmp(str, "identify"))
         return CL_ACTION_IDENTIFY;
     if (!strcmp(str, "id"))
@@ -72,6 +74,8 @@ const char * clActionToString(struct clContext * C, clAction action)
     switch (action) {
         case CL_ACTION_NONE:
             return "--";
+        case CL_ACTION_HIGHLIGHT:
+            return "highlight";
         case CL_ACTION_IDENTIFY:
             return "identify";
         case CL_ACTION_GENERATE:
@@ -959,7 +963,7 @@ clBool clContextParseArgs(clContext * C, int argc, const char * argv[])
             if (C->action == CL_ACTION_NONE) {
                 C->action = clActionFromString(C, arg);
                 if (C->action == CL_ACTION_ERROR) {
-                    clContextLogError(C, "unknown action '%s', expecting convert, identify, or generate", arg);
+                    clContextLogError(C, "unknown action '%s', expecting convert, identify, generate, or highlight", arg);
                 }
             } else if (filenames[0] == NULL) {
                 filenames[0] = arg;
@@ -1034,6 +1038,19 @@ clBool clContextParseArgs(clContext * C, int argc, const char * argv[])
             }
             break;
 
+        case CL_ACTION_HIGHLIGHT:
+            C->inputFilename = filenames[0];
+            if (!C->inputFilename) {
+                clContextLogError(C, "highlight requires an input filename.");
+                return clFalse;
+            }
+            C->outputFilename = filenames[1];
+            if (!C->outputFilename) {
+                clContextLogError(C, "highlight requires an output filename.");
+                return clFalse;
+            }
+            break;
+
         case CL_ACTION_ERROR:
             return clFalse;
 
@@ -1066,12 +1083,13 @@ void clContextPrintSyntax(clContext * C)
         strcat(formatLine, record->format.name);
     }
 
-    clContextLog(C, NULL, 0, "Syntax: colorist convert  [input]        [output]       [OPTIONS]");
-    clContextLog(C, NULL, 0, "        colorist identify [input]                       [OPTIONS]");
-    clContextLog(C, NULL, 0, "        colorist generate                [output.icc]   [OPTIONS]");
-    clContextLog(C, NULL, 0, "        colorist generate [image string] [output image] [OPTIONS]");
-    clContextLog(C, NULL, 0, "        colorist modify   [input.icc]    [output.icc]   [OPTIONS]");
-    clContextLog(C, NULL, 0, "        colorist calc     [image string]                [OPTIONS]");
+    clContextLog(C, NULL, 0, "Syntax: colorist convert   [input]        [output]       [OPTIONS]");
+    clContextLog(C, NULL, 0, "        colorist identify  [input]                       [OPTIONS]");
+    clContextLog(C, NULL, 0, "        colorist generate                 [output.icc]   [OPTIONS]");
+    clContextLog(C, NULL, 0, "        colorist generate  [image string] [output image] [OPTIONS]");
+    clContextLog(C, NULL, 0, "        colorist modify    [input.icc]    [output.icc]   [OPTIONS]");
+    clContextLog(C, NULL, 0, "        colorist highlight [input]        [output]       [OPTIONS]");
+    clContextLog(C, NULL, 0, "        colorist calc      [image string]                [OPTIONS]");
     clContextLog(C, NULL, 0, "");
     clContextLog(C, NULL, 0, "Basic Options:");
     clContextLog(C, NULL, 0, "    -h,--help                : Display this help");

--- a/lib/src/context_highlight.c
+++ b/lib/src/context_highlight.c
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+//                         Copyright Joe Drago 2018.
+//         Distributed under the Boost Software License, Version 1.0.
+//            (See accompanying file LICENSE_1_0.txt or copy at
+//                  http://www.boost.org/LICENSE_1_0.txt)
+// ---------------------------------------------------------------------------
+
+#include "colorist/context.h"
+#include "colorist/image.h"
+#include "colorist/types.h"
+
+#include <string.h>
+
+#define FAIL()              \
+    {                       \
+        returnCode = 1;     \
+        goto reportCleanup; \
+    }
+
+int clContextHighlight(clContext * C)
+{
+    Timer overall, t;
+    int returnCode = 0;
+
+    clContextLog(C, "action", 0, "Highlight: %s -> %s", C->inputFilename, C->outputFilename);
+    timerStart(&overall);
+
+    clContextLog(C, "decode", 0, "Reading: %s (%d bytes)", C->inputFilename, clFileSize(C->inputFilename));
+    timerStart(&t);
+    clImage * image = clContextRead(C, C->inputFilename, C->iccOverrideIn, NULL);
+    if (image == NULL) {
+        return 1;
+    }
+    clContextLog(C, "timing", -1, TIMING_FORMAT, timerElapsedSeconds(&t));
+
+    timerStart(&t);
+    {
+        clImage * highlight = NULL;
+        clImageHDRStats highlightStats;
+        clImageMeasureHDR(C, image, C->defaultLuminance, 0.0f, &highlight, &highlightStats, NULL, NULL);
+        if (!highlight) {
+            FAIL();
+        }
+        clWriteParams writeParams;
+        clWriteParamsSetDefaults(C, &writeParams);
+        if (!clContextWrite(C, highlight, C->outputFilename, "png", &writeParams)) {
+            FAIL();
+        }
+    }
+
+    clContextLog(C, "encode", 1, "Wrote %d bytes.", clFileSize(C->outputFilename));
+    clContextLog(C, "timing", -1, TIMING_FORMAT, timerElapsedSeconds(&t));
+
+reportCleanup:
+    if (image)
+        clImageDestroy(C, image);
+
+    if (returnCode == 0) {
+        clContextLog(C, "action", 0, "Highlight complete.");
+        clContextLog(C, "timing", -1, OVERALL_TIMING_FORMAT, timerElapsedSeconds(&overall));
+    }
+    return returnCode;
+}


### PR DESCRIPTION
Hi, hope you don't mind receiving pull requests from a random user on Github.

I'm using colorist on Linux to generate simple visual reports on HDR images (as a quick way of seeing what parts of the image are out of gamut or overbright). You have a tool that can do this ([Vantage](https://github.com/joedrago/vantage)), but it appears to rely on some Windows and Mac specific stuff so I couldn't get it running on Linux. Plus I didn't really want / need a GUI for this task. And from my brief testing on Mac, there didn't appear to be any way to save a PNG image to use as a static and easily sharable representation of the image.

Anyway, cribbing heavily from code I found elsewhere in Colorist, I added this capability as a new command, `highlight`. Because it doesn't generate a full report like Vantage it's very fast to run, handling a 4K input file in just a few seconds for me.

I'm sending this pull request in case you'd like to add this function to Colorist. I discovered Colorist through a Netflix blog post (which didn't mention it by name), but I suspect many others may do the same and generating static reports like this one with a command line tool seems like a useful function to me.

A follow up commit might print the highlight stats to the terminal. This depends on whether I have time to work on it.