### PR TITLE
clFormatWriteJPG: Declare outsize as unsigned long

### DIFF
--- a/lib/src/format_jpg.c
+++ b/lib/src/format_jpg.c
@@ -126,7 +126,7 @@ clBool clFormatWriteJPG(struct clContext * C, struct clImage * image, const char
     JSAMPROW row_pointer[1];
     int row_stride;
     unsigned char * outbuffer = NULL;
-    size_t outsize = 0;
+    unsigned long outsize = 0;
 
     clRaw rawProfile = CL_RAW_EMPTY;
     if (!clProfilePack(C, image->profile, &rawProfile)) {


### PR DESCRIPTION
The address of the variable 'outsize' is passed to jpeg_mem_dest()
as the third argument, which should have the type unsigned long *.
In 64-bit Windows, size_t and unsigned long are different: size_t is
64 bits, but unsigned long is still 32 bits.